### PR TITLE
fix: update Sparkle and harden App Server output handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,12 @@ has changed.
   drain both stdout and stderr, retain only a bounded in-memory diagnostic tail,
   detach file-handle callbacks at EOF or process termination, and close retained
   handles during teardown so pipe readiness cannot create a CPU spin loop.
+  Bound stdout reads to 64 KiB and each JSON-RPC line to 1 MiB with main-queue
+  backpressure; stop the child and mark the retained snapshot stale on overflow.
+  Reset framing state at teardown and ignore output from replaced processes.
+  Read stderr in at most 8 KiB chunks without an unbounded termination read.
+  Display only locally authored errors selected by protocol code, never raw
+  App Server error messages/data or system exception descriptions.
 - `Core/QuotaModels.swift` contains pure quota, remaining-time, and consumption-
   pace calculations shared with the Swift Package unit tests.
 - `Core/RateLimitResetCredits.swift` decodes optional banked-reset summaries and
@@ -231,7 +237,8 @@ Codex App Server.
   quota fields and token counts, but never an account key, account email,
   authentication data, or raw App Server responses.
 - Use Sparkle's HTTPS appcast and EdDSA verification for every downloadable
-  update. Keep the public key in `Config/CodexMeter-Info.plist` and the private
+  update. Require Sparkle 2.9.6 or later for its security fixes.
+  Keep the public key in `Config/CodexMeter-Info.plist` and the private
   key only in the maintainer's login Keychain. Check daily, keep stable as the
   default channel, and use `beta` only when prereleases are enabled. Automatic
   download and installation must remain an explicit user preference.

--- a/CodexMeter.xcodeproj/project.pbxproj
+++ b/CodexMeter.xcodeproj/project.pbxproj
@@ -339,7 +339,7 @@
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.9.5;
+				minimumVersion = 2.9.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/CodexMeter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodexMeter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
-        "version" : "2.9.5"
+        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
+        "version" : "2.9.6"
       }
     }
   ],

--- a/CodexMeter/CodexUsageService.swift
+++ b/CodexMeter/CodexUsageService.swift
@@ -32,7 +32,7 @@ final class CodexUsageService: ObservableObject {
     private var inputHandle: FileHandle?
     private var outputHandle: FileHandle?
     private var errorHandle: FileHandle?
-    private var outputBuffer = Data()
+    private var outputBuffer = CodexRPCLineBuffer()
     private var standardErrorBuffer = Data()
     private let standardErrorBufferLock = NSLock()
     private let maximumStandardErrorBytes = 8 * 1_024
@@ -121,19 +121,32 @@ final class CodexUsageService: ObservableObject {
         let outputHandle = outputPipe.fileHandleForReading
         let errorHandle = errorPipe.fileHandleForReading
 
-        outputHandle.readabilityHandler = { [weak self] handle in
-            let data = handle.availableData
-            guard !data.isEmpty else {
+        outputHandle.readabilityHandler = { [weak self, weak process] handle in
+            do {
+                let data = try CodexProcessPipe.readAvailableData(from: handle, maximumBytes: 64 * 1_024)
+                guard !data.isEmpty else {
+                    handle.readabilityHandler = nil
+                    return
+                }
+                // Backpressure bounds queued output too. FileHandle invokes this on
+                // its background queue; framing and process state stay on the main queue.
+                DispatchQueue.main.sync {
+                    guard let self, self.process === process else { return }
+                    self.consumeOutput(data)
+                }
+            } catch {
                 handle.readabilityHandler = nil
-                return
+                DispatchQueue.main.sync {
+                    guard let self, self.process === process else { return }
+                    self.stopAppServerForOutputFailure(L10n.string("error.communication"))
+                }
             }
-            self?.consumeOutput(data)
         }
 
         resetStandardErrorBuffer()
         errorHandle.readabilityHandler = { [weak self] handle in
-            let data = handle.availableData
-            guard !data.isEmpty else {
+            guard let data = try? CodexProcessPipe.readAvailableData(from: handle, maximumBytes: 8 * 1_024),
+                  !data.isEmpty else {
                 handle.readabilityHandler = nil
                 return
             }
@@ -146,9 +159,6 @@ final class CodexUsageService: ObservableObject {
         process.terminationHandler = { [weak self, weak process] terminatedProcess in
             outputHandle.readabilityHandler = nil
             errorHandle.readabilityHandler = nil
-            if let trailingData = try? errorHandle.readToEnd() {
-                self?.consumeStandardError(trailingData)
-            }
 
             let terminationStatus = terminatedProcess.terminationStatus
             let terminationReason = terminatedProcess.terminationReason
@@ -193,7 +203,7 @@ final class CodexUsageService: ObservableObject {
             outputHandle.readabilityHandler = nil
             errorHandle.readabilityHandler = nil
             clearAppServerResources()
-            markFailure(L10n.format("error.app_server_start_format", error.localizedDescription))
+            markFailure(L10n.string("error.app_server_start_failed"))
         }
     }
 
@@ -302,6 +312,7 @@ final class CodexUsageService: ObservableObject {
         inputHandle = nil
         outputHandle = nil
         errorHandle = nil
+        outputBuffer = CodexRPCLineBuffer()
 
         if terminate, runningProcess?.isRunning == true {
             runningProcess?.terminate()
@@ -336,28 +347,39 @@ final class CodexUsageService: ObservableObject {
             try inputHandle.write(contentsOf: data)
             return true
         } catch {
-            markFailure(L10n.format("error.communication_format", error.localizedDescription))
+            markFailure(L10n.string("error.communication"))
             return false
         }
     }
 
     private func consumeOutput(_ data: Data) {
-        // Pipe reads may split or combine messages, so retain bytes until a newline.
-        outputBuffer.append(data)
-
-        while let newlineIndex = outputBuffer.firstIndex(of: 0x0A) {
-            let line = outputBuffer[..<newlineIndex]
-            outputBuffer.removeSubrange(...newlineIndex)
-
-            guard !line.isEmpty,
-                  let object = try? JSONSerialization.jsonObject(with: Data(line)) as? [String: Any] else {
-                continue
+        let sourceProcess = process
+        do {
+            for line in try outputBuffer.append(data) {
+                // A response may restart the child; discard its remaining messages.
+                guard process === sourceProcess else { return }
+                guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any] else {
+                    continue
+                }
+                handleMessage(object)
             }
-
-            DispatchQueue.main.async { [weak self] in
-                self?.handleMessage(object)
-            }
+        } catch {
+            stopAppServerForOutputFailure(L10n.string("error.app_server_output_too_large"))
         }
+    }
+
+    private func stopAppServerForOutputFailure(_ message: String) {
+        restartWorkItem?.cancel()
+        restartWorkItem = nil
+        cancelRefreshTimeout()
+        cancelUsageTimeout()
+        pendingRequests.removeAll()
+        rateLimitRequestSources.removeAll()
+        usageRequestID = nil
+        didInitialize = false
+        clearAppServerResources(terminate: true)
+        resetStandardErrorBuffer()
+        markFailure(message)
     }
 
     private func consumeStandardError(_ data: Data) {
@@ -437,7 +459,7 @@ final class CodexUsageService: ObservableObject {
         }
 
         if let error = message["error"] as? [String: Any] {
-            let text = error["message"] as? String ?? L10n.string("error.unknown")
+            let text = L10n.string(CodexProcessDiagnostic.rpcErrorLocalizationKey(error))
             if (kind == .account || kind == .rateLimits),
                restartAppServerAfterAccountFailure() {
                 return

--- a/CodexMeter/Core/CodexProcessSupport.swift
+++ b/CodexMeter/Core/CodexProcessSupport.swift
@@ -1,4 +1,24 @@
 import Foundation
+import Darwin
+
+enum CodexProcessPipe {
+    static func readAvailableData(from handle: FileHandle, maximumBytes: Int) throws -> Data {
+        precondition(maximumBytes > 0)
+        var data = Data(count: maximumBytes)
+        let count = data.withUnsafeMutableBytes { bytes in
+            // One POSIX read returns available pipe bytes immediately. Foundation's
+            // length-based reads can wait for more bytes and stall a JSON-RPC exchange.
+            var result: Int
+            repeat {
+                result = Darwin.read(handle.fileDescriptor, bytes.baseAddress, maximumBytes)
+            } while result < 0 && errno == EINTR
+            return result
+        }
+        guard count >= 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+        data.count = count
+        return data
+    }
+}
 
 enum CodexProcessEnvironment {
     static func make(
@@ -28,9 +48,55 @@ enum CodexProcessEnvironment {
 }
 
 enum CodexProcessDiagnostic {
+    static func rpcErrorLocalizationKey(_ error: [String: Any]) -> String {
+        // Upstream messages and error data can contain credentials or account details.
+        // Only allow known protocol codes to select locally authored UI text.
+        switch error["code"] as? Int {
+        case -32601: return "error.app_server_method_unavailable"
+        default: return "error.app_server_request_failed"
+        }
+    }
+
     static func isNodeRuntimeMissing(in standardError: Data) -> Bool {
         let message = String(decoding: standardError, as: UTF8.self).lowercased()
         return message.contains("env: node: no such file or directory")
             || message.contains("node: command not found")
+    }
+}
+
+/// Frames newline-delimited JSON without retaining an unbounded partial response.
+struct CodexRPCLineBuffer: Sendable {
+    enum Failure: Error {
+        case messageTooLarge
+    }
+
+    let maximumMessageBytes: Int
+    private(set) var bufferedData = Data()
+
+    init(maximumMessageBytes: Int = 1_024 * 1_024) {
+        precondition(maximumMessageBytes > 0)
+        self.maximumMessageBytes = maximumMessageBytes
+    }
+
+    mutating func append(_ data: Data) throws -> [Data] {
+        var lines: [Data] = []
+        var start = data.startIndex
+        while start < data.endIndex {
+            let newline = data[start...].firstIndex(of: 0x0A)
+            let end = newline ?? data.endIndex
+            let fragment = data[start..<end]
+            guard fragment.count <= maximumMessageBytes - bufferedData.count else {
+                bufferedData = Data()
+                throw Failure.messageTooLarge
+            }
+            bufferedData.append(contentsOf: fragment)
+            guard let newline else { break }
+            if !bufferedData.isEmpty {
+                lines.append(bufferedData)
+                bufferedData = Data()
+            }
+            start = data.index(after: newline)
+        }
+        return lines
     }
 }

--- a/CodexMeter/Localizable.xcstrings
+++ b/CodexMeter/Localizable.xcstrings
@@ -2703,6 +2703,98 @@
         }
       }
     },
+    "error.app_server_method_unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This Codex App Server does not support the requested feature."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前 Codex App Server 不支持请求的功能。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前的 Codex App Server 不支援要求的功能。"
+          }
+        }
+      }
+    },
+    "error.app_server_output_too_large": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex App Server returned an oversized response and was stopped. Try refreshing or updating Codex CLI."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex App Server 返回的数据过大，已停止连接。请尝试刷新或更新 Codex CLI。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex App Server 回傳的資料過大，已停止連線。請嘗試重新整理或更新 Codex CLI。"
+          }
+        }
+      }
+    },
+    "error.app_server_request_failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex App Server could not complete the request. Try refreshing and check your Codex login if the problem persists."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex App Server 无法完成请求。请尝试刷新；若问题持续，请检查 Codex 登录状态。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex App Server 無法完成要求。請嘗試重新整理；若問題持續，請檢查 Codex 登入狀態。"
+          }
+        }
+      }
+    },
+    "error.app_server_start_failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not start Codex App Server. Check your Codex CLI installation."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法启动 Codex App Server。请检查 Codex CLI 安装。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法啟動 Codex App Server。請檢查 Codex CLI 安裝。"
+          }
+        }
+      }
+    },
     "error.app_server_start_format" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/README.md
+++ b/README.md
@@ -268,6 +268,14 @@ verification checklist, and planned developer customization options.
 - It does not copy or persist Codex access tokens.
 - It does not read Codex authentication files directly.
 - It does not log account email addresses or raw authentication responses.
+- App Server errors use locally authored messages instead of displaying raw
+  server errors or system exception details that could contain private data.
+- App Server output is read in bounded chunks. A response line over 1 MiB stops
+  the child connection and marks the last successful quota as stale; a manual
+  or scheduled refresh can reconnect. Diagnostic stderr stays in an 8 KiB
+  in-memory tail and is never displayed verbatim.
+- In-app updates require Sparkle 2.9.6 or later and retain HTTPS transport and
+  EdDSA archive verification.
 - It separates ChatGPT account history with a salted SHA-256 key derived
   locally from the account type and normalized email. Neither the email nor
   this internal key is included in CSV exports.

--- a/Tests/CodexMeterCoreTests/CodexProcessSupportTests.swift
+++ b/Tests/CodexMeterCoreTests/CodexProcessSupportTests.swift
@@ -3,6 +3,111 @@ import XCTest
 @testable import CodexMeterCore
 
 final class CodexProcessSupportTests: XCTestCase {
+    func testBoundedPipeReadReturnsShortMessagesWhileWriterRemainsOpen() throws {
+        let pipe = Pipe()
+        defer {
+            try? pipe.fileHandleForReading.close()
+            try? pipe.fileHandleForWriting.close()
+        }
+        try pipe.fileHandleForWriting.write(contentsOf: Data("hello".utf8))
+        XCTAssertEqual(
+            try CodexProcessPipe.readAvailableData(from: pipe.fileHandleForReading, maximumBytes: 2),
+            Data("he".utf8)
+        )
+        XCTAssertEqual(
+            try CodexProcessPipe.readAvailableData(from: pipe.fileHandleForReading, maximumBytes: 64 * 1_024),
+            Data("llo".utf8)
+        )
+        try pipe.fileHandleForWriting.close()
+        XCTAssertTrue(try CodexProcessPipe.readAvailableData(
+            from: pipe.fileHandleForReading, maximumBytes: 64 * 1_024
+        ).isEmpty)
+    }
+
+    func testRPCFramingPreservesSplitUTF8AndMultipleMessages() throws {
+        var buffer = CodexRPCLineBuffer()
+        let first = Data("{\"text\":\"中文\"}".utf8)
+        let split = first.firstIndex(of: 0xE4)! + 1
+        XCTAssertEqual(try buffer.append(first.prefix(split)), [])
+        let remainder = first.suffix(from: split) + Data("\n\n{\"id\":2}\npartial".utf8)
+        XCTAssertEqual(try buffer.append(remainder), [first, Data("{\"id\":2}".utf8)])
+        XCTAssertEqual(buffer.bufferedData, Data("partial".utf8))
+    }
+
+    func testRPCFramingAcceptsExactByteLimitBeforeNewline() throws {
+        var buffer = CodexRPCLineBuffer(maximumMessageBytes: 8)
+        XCTAssertEqual(try buffer.append(Data("12345678".utf8)), [])
+        XCTAssertEqual(try buffer.append(Data("\n".utf8)), [Data("12345678".utf8)])
+        XCTAssertTrue(buffer.bufferedData.isEmpty)
+    }
+
+    func testRPCFramingRejectsOversizedPartialAndReleasesBufferedBytes() throws {
+        var buffer = CodexRPCLineBuffer(maximumMessageBytes: 8)
+        _ = try buffer.append(Data("12345678".utf8))
+        XCTAssertThrowsError(try buffer.append(Data("9".utf8))) { error in
+            guard case CodexRPCLineBuffer.Failure.messageTooLarge = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+        XCTAssertTrue(buffer.bufferedData.isEmpty)
+    }
+
+    func testRPCFramingRejectsOversizedCompleteMessage() {
+        var buffer = CodexRPCLineBuffer(maximumMessageBytes: 8)
+        XCTAssertThrowsError(try buffer.append(Data("123456789\n".utf8)))
+        XCTAssertTrue(buffer.bufferedData.isEmpty)
+    }
+
+    func testRPCFramingLimitsEachMessageRatherThanCombinedRead() throws {
+        var buffer = CodexRPCLineBuffer(maximumMessageBytes: 4)
+        XCTAssertEqual(
+            try buffer.append(Data("1234\n5678\n9012\n".utf8)),
+            [Data("1234".utf8), Data("5678".utf8), Data("9012".utf8)]
+        )
+        XCTAssertTrue(buffer.bufferedData.isEmpty)
+    }
+
+    func testRPCFramingRejectsSustainedUnterminatedOutputAtProductionLimit() throws {
+        var buffer = CodexRPCLineBuffer()
+        let chunk = Data(repeating: 0x61, count: 64 * 1_024)
+        for _ in 0..<16 {
+            XCTAssertEqual(try buffer.append(chunk), [])
+        }
+        XCTAssertEqual(buffer.bufferedData.count, 1_024 * 1_024)
+        XCTAssertThrowsError(try buffer.append(chunk))
+        XCTAssertTrue(buffer.bufferedData.isEmpty)
+    }
+
+    func testRPCErrorDoesNotExposeMessageOrNestedData() {
+        let sensitiveError: [String: Any] = [
+            "code": -32000,
+            "message": "user@example.com Authorization: Bearer secret-token /Users/example/auth.json",
+            "data": ["refresh_token": "another-secret"]
+        ]
+        XCTAssertEqual(
+            CodexProcessDiagnostic.rpcErrorLocalizationKey(sensitiveError),
+            "error.app_server_request_failed"
+        )
+        XCTAssertEqual(
+            CodexProcessDiagnostic.rpcErrorLocalizationKey([:]),
+            "error.app_server_request_failed"
+        )
+        XCTAssertEqual(
+            CodexProcessDiagnostic.rpcErrorLocalizationKey(["code": "user@example.com"]),
+            "error.app_server_request_failed"
+        )
+    }
+
+    func testRPCMethodUnavailableUsesOnlyKnownNumericCode() {
+        XCTAssertEqual(
+            CodexProcessDiagnostic.rpcErrorLocalizationKey([
+                "code": -32601,
+                "message": "secret-token"
+            ]),
+            "error.app_server_method_unavailable"
+        )
+    }
+
     func testEnvironmentLaunchesEnvNodeScriptWithMinimalInheritedPath() throws {
         let fileManager = FileManager.default
         let temporaryDirectory = fileManager.temporaryDirectory


### PR DESCRIPTION
This change bounds App Server output buffering and prevents raw error
messages from exposing account or credential details in the UI.

- Upgrade Sparkle to 2.9.6.
- Limit stdout reads to 64 KiB and JSON-RPC messages to 1 MiB.
- Stop oversized responses while preserving stale quota and allowing reconnect.
- Replace raw errors with localized messages in all three supported languages.
- Add regression tests and update documentation.

Validation:
- All 87 unit tests passed.
- Subprocess smoke tests passed for oversized output, safe error messages,
  stale quota preservation, and reconnect.
- Full app build passed using Xcode 26.6 with a temporary compatible project
  copy and the checksum-verified Sparkle 2.9.6 package.
  The repository's project format remains unchanged.