### PR TITLE
fix: discover Codex installed by NVM

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,10 @@ has changed.
   refresh/freshness state. Build a deterministic child-process `PATH` from the
   selected Codex executable directory plus common local package locations so
   npm-installed launchers can find Node without invoking a login shell. Always
-  drain both stdout and stderr, retain only a bounded in-memory diagnostic tail,
+  discover Codex installed under NVM version directories as well as the stable
+  local, Homebrew, and npm-global locations. Prefer stable direct locations
+  before selecting the newest executable NVM installation. Always drain both
+  stdout and stderr, retain only a bounded in-memory diagnostic tail,
   detach file-handle callbacks at EOF or process termination, and close retained
   handles during teardown so pipe readiness cannot create a CPU spin loop.
   Bound stdout reads to 64 KiB and each JSON-RPC line to 1 MiB with main-queue

--- a/CodexMeter/CodexUsageService.swift
+++ b/CodexMeter/CodexUsageService.swift
@@ -867,18 +867,9 @@ final class CodexUsageService: ObservableObject {
     }
 
     private func locateCodexExecutable() -> URL? {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        // Keep discovery deterministic and never invoke a shell to resolve PATH.
-        let candidates = [
-            "\(home)/.local/bin/codex",
-            "/opt/homebrew/bin/codex",
-            "/usr/local/bin/codex",
-            "\(home)/.npm-global/bin/codex"
-        ]
-
-        return candidates
-            .first(where: FileManager.default.isExecutableFile(atPath:))
-            .map(URL.init(fileURLWithPath:))
+        CodexExecutableLocator.locate(
+            homeDirectory: FileManager.default.homeDirectoryForCurrentUser
+        )
     }
 
     private var appVersion: String {

--- a/CodexMeter/Core/CodexProcessSupport.swift
+++ b/CodexMeter/Core/CodexProcessSupport.swift
@@ -1,6 +1,50 @@
 import Foundation
 import Darwin
 
+enum CodexExecutableLocator {
+    static func locate(
+        homeDirectory: URL,
+        fileManager: FileManager = .default,
+        systemCandidateURLs: [URL] = [
+            URL(fileURLWithPath: "/opt/homebrew/bin/codex"),
+            URL(fileURLWithPath: "/usr/local/bin/codex")
+        ]
+    ) -> URL? {
+        let directCandidates = [
+            homeDirectory.appendingPathComponent(".local/bin/codex")
+        ] + systemCandidateURLs + [
+            homeDirectory.appendingPathComponent(".npm-global/bin/codex")
+        ]
+
+        if let directMatch = directCandidates.first(where: {
+            fileManager.isExecutableFile(atPath: $0.path)
+        }) {
+            return directMatch
+        }
+
+        let nvmVersionsDirectory = homeDirectory.appendingPathComponent(
+            ".nvm/versions/node",
+            isDirectory: true
+        )
+        let nvmVersions = (try? fileManager.contentsOfDirectory(
+            at: nvmVersionsDirectory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )) ?? []
+
+        return nvmVersions
+            .sorted {
+                $0.lastPathComponent.compare(
+                    $1.lastPathComponent,
+                    options: [.numeric, .caseInsensitive]
+                ) == .orderedDescending
+            }
+            .lazy
+            .map { $0.appendingPathComponent("bin/codex") }
+            .first(where: { fileManager.isExecutableFile(atPath: $0.path) })
+    }
+}
+
 enum CodexProcessPipe {
     static func readAvailableData(from handle: FileHandle, maximumBytes: Int) throws -> Data {
         precondition(maximumBytes > 0)

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ CodexMeter currently discovers `codex` in these locations:
 /opt/homebrew/bin/codex
 /usr/local/bin/codex
 ~/.npm-global/bin/codex
+~/.nvm/versions/node/*/bin/codex
 ```
 
 ## Build and Run
@@ -293,8 +294,8 @@ Mac App Store distribution.
 ## Known Limitations
 
 - Codex App Server is experimental and may change without notice.
-- Codex executable discovery currently uses a fixed list of common install
-  locations rather than the interactive shell's `PATH`.
+- Codex executable discovery uses common stable install locations and installed
+  NVM Node versions rather than the interactive shell's `PATH`.
 - Notification and launch-at-login behavior must be tested with a signed build.
 - Token activity is optional and may be unavailable for API-key, Bedrock, or
   other account types even when quota windows are available.

--- a/Tests/CodexMeterCoreTests/CodexProcessSupportTests.swift
+++ b/Tests/CodexMeterCoreTests/CodexProcessSupportTests.swift
@@ -3,6 +3,54 @@ import XCTest
 @testable import CodexMeterCore
 
 final class CodexProcessSupportTests: XCTestCase {
+    func testExecutableLocatorFindsCodexInstalledByNVM() throws {
+        let fileManager = FileManager.default
+        let homeDirectory = fileManager.temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let olderCodexURL = homeDirectory.appendingPathComponent(
+            ".nvm/versions/node/v20.19.0/bin/codex"
+        )
+        let currentCodexURL = homeDirectory.appendingPathComponent(
+            ".nvm/versions/node/v24.18.0/bin/codex"
+        )
+        defer { try? fileManager.removeItem(at: homeDirectory) }
+
+        try makeExecutable(at: olderCodexURL, fileManager: fileManager)
+        try makeExecutable(at: currentCodexURL, fileManager: fileManager)
+
+        XCTAssertEqual(
+            CodexExecutableLocator.locate(
+                homeDirectory: homeDirectory,
+                fileManager: fileManager,
+                systemCandidateURLs: []
+            )?.resolvingSymlinksInPath(),
+            currentCodexURL.resolvingSymlinksInPath()
+        )
+    }
+
+    func testExecutableLocatorPrefersStableDirectLocationsOverNVM() throws {
+        let fileManager = FileManager.default
+        let homeDirectory = fileManager.temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let directCodexURL = homeDirectory.appendingPathComponent(".local/bin/codex")
+        let nvmCodexURL = homeDirectory.appendingPathComponent(
+            ".nvm/versions/node/v24.18.0/bin/codex"
+        )
+        defer { try? fileManager.removeItem(at: homeDirectory) }
+
+        try makeExecutable(at: directCodexURL, fileManager: fileManager)
+        try makeExecutable(at: nvmCodexURL, fileManager: fileManager)
+
+        XCTAssertEqual(
+            CodexExecutableLocator.locate(
+                homeDirectory: homeDirectory,
+                fileManager: fileManager,
+                systemCandidateURLs: []
+            )?.resolvingSymlinksInPath(),
+            directCodexURL.resolvingSymlinksInPath()
+        )
+    }
+
     func testBoundedPipeReadReturnsShortMessagesWhileWriterRemainsOpen() throws {
         let pipe = Pipe()
         defer {
@@ -201,5 +249,17 @@ final class CodexProcessSupportTests: XCTestCase {
         let standardError = Data("warning: retrying request\n".utf8)
 
         XCTAssertFalse(CodexProcessDiagnostic.isNodeRuntimeMissing(in: standardError))
+    }
+
+    private func makeExecutable(at url: URL, fileManager: FileManager) throws {
+        try fileManager.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: url)
+        try fileManager.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: url.path
+        )
     }
 }


### PR DESCRIPTION
## Summary

- discover Codex executables installed under ~/.nvm/versions/node/*/bin/codex
- preserve the existing stable-path precedence, then select the newest executable NVM installation
- keep the selected CLI directory at the front of the child PATH so npm launchers can resolve Node
- add focused discovery tests and update the public documentation

## Reproduction

CodexMeter 1.5.5 reports that Codex CLI is missing when Codex is installed in the default NVM directory, even though the CLI is installed and codex login status succeeds. This is a follow-up to #2: the PATH fix there handles npm installations in the existing fixed locations, but executable discovery still excludes NVM version directories.

## Validation

- swift build passes
- a standalone locator smoke test finds the real NVM-installed CLI and selects the newest executable fake NVM version
- a locally compiled and ad-hoc-signed 1.5.5 build launches the NVM Codex App Server and records fresh non-stale quota samples
- swift test could not run in this Command Line Tools-only environment because XCTest is unavailable (no such module XCTest)